### PR TITLE
only exclude root-level lib

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,7 @@ abis.json
 ganache.log
 
 # build directories
-lib/
+/lib/
 
 # editors
 .vscode


### PR DESCRIPTION
with the previous gitignore, any directory called `lib` was ignored