### PR TITLE
support custom timeout in nonceRegistry

### DIFF
--- a/test/integration/commitReveal.spec.ts
+++ b/test/integration/commitReveal.spec.ts
@@ -116,13 +116,14 @@ async function setChannelNonceAndWait(
   await multisig.execCall(
     nonceRegistry,
     "setNonce",
-    [channelNonceSalt, channelNonceValue],
+    [new ethers.BigNumber(10), channelNonceSalt, channelNonceValue],
     signers
   );
 
   await mineBlocks(10);
 
   const channelNonceKey = computeNonceRegistryKey(
+    new ethers.BigNumber(10),
     multisig.address,
     channelNonceSalt
   );

--- a/utils/stateChannel.ts
+++ b/utils/stateChannel.ts
@@ -161,12 +161,13 @@ export function computeActionHash(
  * @returns string 32-byte keccak256 hash
  */
 export function computeNonceRegistryKey(
+  timeout: ethers.BigNumber,
   multisigAddress: string,
   nonceSalt: string
 ) {
   return ethers.utils.solidityKeccak256(
-    ["address", "bytes32"],
-    [multisigAddress, nonceSalt]
+    ["address", "uint256", "bytes32"],
+    [multisigAddress, timeout, nonceSalt]
   );
 }
 


### PR DESCRIPTION
This PR allows the nonce registry to support custom timeouts by making the timeout parameter part of the key. This allows allows us to remove the `finalizeNonce` function (you can simply set a nonce with timeout 0).

This PR also fixes a bug where it was possible to reset a nonce after the timeout, and adds some documentation.

This PR also does not extend the timeout if a nonce has already been set before.

NB: @emansipater has described an alternative design that stores the last two finalization times in the nonce, and allows dependents to specify their own timeout.