### PR TITLE
make terms.limit an upper bound

### DIFF
--- a/contracts/lib/Transfer.sol
+++ b/contracts/lib/Transfer.sol
@@ -65,7 +65,7 @@ library Transfer {
     for (uint256 i = 0; i < details.amount.length; i++) {
       sum += details.amount[i];
     }
-    return sum == terms.limit;
+    return sum <= terms.limit;
   }
 
 }


### PR DESCRIPTION
IMO `terms.limit` being an upper bound is better. The current behaviour is

1. if `details > limit`, fail
1. if `details < limit`, fail

this new behaviour removes case (2), which makes sense to me