### PR TITLE
link to specs repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ When disputes occur, an instance of the contract [`StateChannel.sol`](./contract
 
 State deposit is stored in a [multisig wallet](./contracts/MinimumViableMultisig.sol). Apps are installed by signing [commitments](./contracts/delegateTargets/ConditionalTransfer.sol) from the multisig. Deterministic addressing for counterfactually instantiated objects is provided through a [registry](./contracts/Registry.sol).
 
-For a more detailed description of contract architecture, please see [ARCHITECTURE.md](./ARCHITECTURE.md).
+For a more detailed description of contract architecture, please see [the specs repository](https://github.com/counterfactual/specs/tree/master/contracts).
 
 ### Security
 


### PR DESCRIPTION
This PR replaces an old link to the file `ARCHITECTURE.md` with a link to the new home of the file